### PR TITLE
Set colormap on init

### DIFF
--- a/docs/source/api_reference/isocolor.rst
+++ b/docs/source/api_reference/isocolor.rst
@@ -3,9 +3,6 @@ IsoColor
 
 The ``IsoColor`` widget colorize your mesh given.
 
-.. note::
-    Currently, you can only use the default Viridis colormap, we'd like to support all paraview colormaps
-
 The ``input`` attribute should be the name of the ``Component`` you want to use for colorizing the mesh. You also need to pass the ``min`` and ``max`` (or ``range`` as a min/max tuple) of the component array.
 
 For example, if you have a 1-D ``Data`` named ``"height"``, you can simply pass its name as input:
@@ -73,8 +70,8 @@ Examples
     height_min = np.min(z)
     height_max = np.max(z)
 
-    # Colorize by height
-    colored_mesh = IsoColor(mesh, input='height', min=height_min, max=height_max)
+    # Colorize by height and set the colormap to "Turbo"
+    colored_mesh = IsoColor(mesh, input='height', min=height_min, max=height_max, colormap='Turbo')
 
     # Create a slider that will dynamically change the boundaries of the colormap
     colormap_slider_range = FloatRangeSlider(value=[height_min, height_max], min=height_min, max=height_max, step=(height_max - height_min) / 100.)

--- a/ipygany/ipygany.py
+++ b/ipygany/ipygany.py
@@ -651,8 +651,22 @@ class IsoColor(Effect):
     type = Enum(['linear', 'log'], default_value='linear').tag(sync=True)
 
     def __init__(self, parent, **kwargs):
+        colormap = kwargs.pop('colormap', None)
         super().__init__(parent, **kwargs)
         self.range = (self.min, self.max)
+
+        # set colormap
+        if isinstance(colormap, str):
+            if colormap not in colormaps:
+                allowed = ', '.join([f"'{clmp}'" for clmp in colormaps.keys()])
+                raise ValueError('``cmap`` "{cmap} is not supported by ``ipygany``\n'
+                                 'Pick from one of the following:\n'
+                                 + allowed)
+            self.colormap = colormaps[colormap]
+        elif isinstance(colormap, int):
+            self.colormap = colormap
+        elif colormap is not None:
+            raise TypeError(f'Invalid colormap type {type(colormap)}')
 
     @property
     def input_dim(self):

--- a/ipygany/ipygany.py
+++ b/ipygany/ipygany.py
@@ -660,8 +660,7 @@ class IsoColor(Effect):
             if colormap not in colormaps:
                 allowed = ', '.join([f"'{clmp}'" for clmp in colormaps.keys()])
                 raise ValueError('``cmap`` "{cmap} is not supported by ``ipygany``\n'
-                                 'Pick from one of the following:\n'
-                                 + allowed)
+                                 'Pick from one of the following:\n' + allowed)
             self.colormap = colormaps[colormap]
         elif isinstance(colormap, int):
             self.colormap = colormap

--- a/tests/test_ipygany.py
+++ b/tests/test_ipygany.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 
 from ipydatawidgets import NDArrayWidget

--- a/tests/test_isocolor.py
+++ b/tests/test_isocolor.py
@@ -1,8 +1,7 @@
 import pytest
 
-from traitlets import TraitError
-
 from ipygany import PolyMesh, IsoColor
+from ipygany.colormaps import colormaps
 
 from .utils import get_test_assets
 
@@ -12,7 +11,7 @@ def test_default_input():
 
     poly = PolyMesh(vertices=vertices, triangle_indices=triangles, data=[data_1d, data_3d])
 
-    colored_mesh = IsoColor(poly)
+    colored_mesh = IsoColor(poly, colormap='Turbo')
 
     assert colored_mesh.input == '1d'
 
@@ -21,6 +20,25 @@ def test_default_input():
     colored_mesh = IsoColor(poly)
 
     assert colored_mesh.input == (('3d', 'x'), )
+
+
+def test_colormaps():
+    vertices, triangles, data_1d, data_3d = get_test_assets()
+
+    poly = PolyMesh(vertices=vertices, triangle_indices=triangles, data=[data_1d, data_3d])
+
+    colored_mesh = IsoColor(poly, colormap='Turbo')
+    assert colored_mesh.colormap == colormaps.Turbo
+
+    colormap = colormaps.Cividis
+    colored_mesh.colormap = colormap
+    assert colored_mesh.colormap == colormap
+
+    with pytest.raises(ValueError):
+        colored_mesh.colormap = 'InvalidColor'
+
+    with pytest.raises(ValueError):
+        colored_mesh.colormap = -1
 
 
 def test_input():


### PR DESCRIPTION
This PR allows you to set the default colormap on the initialization of `IsoColor`.

```py
import numpy as np
from ipygany import Scene, PolyMesh, Component, IsoColor


# Create triangle indices
Nr = 100
Nc = 100

triangle_indices = np.empty((Nr - 1, Nc - 1, 2, 3), dtype=int)

r = np.arange(Nr * Nc).reshape(Nr, Nc)

triangle_indices[:, :, 0, 0] = r[:-1, :-1]
triangle_indices[:, :, 1, 0] = r[:-1, 1:]
triangle_indices[:, :, 0, 1] = r[:-1, 1:]

triangle_indices[:, :, 1, 1] = r[1:, 1:]
triangle_indices[:, :, :, 2] = r[1:, :-1, None]

triangle_indices.shape = (-1, 3)

# Create vertices
x = np.arange(-5, 5, 0.1)
y = np.arange(-5, 5, 0.1)

xx, yy = np.meshgrid(x, y, sparse=True)

z = np.sin(xx**2 + yy**2) / (xx**2 + yy**2)

vertices = np.empty((100, 100, 3))
vertices[:, :, 0] = xx
vertices[:, :, 1] = yy
vertices[:, :, 2] = z
vertices = vertices.reshape(10000, 3)

height_component = Component(name='value', array=z)

mesh = PolyMesh(
    vertices=vertices,
    triangle_indices=triangle_indices,
    data={'height': [height_component]}
)

# Colorize by curvature
colored_mesh = IsoColor(mesh, input=('height', 'value'), min=np.min(z), max=np.max(z),
                        colormap='Turbo')

scene = Scene([colored_mesh])
scene
```

![jup](https://user-images.githubusercontent.com/11981631/111257853-80cd3500-85e1-11eb-818c-f25e6fece231.png)
